### PR TITLE
Ensure python3 compatibility.

### DIFF
--- a/json_logic/__init__.py
+++ b/json_logic/__init__.py
@@ -10,7 +10,7 @@ def jsonLogic(tests, data=None):
 
   data = data or {}
 
-  op = tests.keys()[0]
+  op = list(tests.keys())[0]
   values = tests[op]
   operations = {
     "=="  : (lambda a, b: a == b),

--- a/json_logic/__init__.py
+++ b/json_logic/__init__.py
@@ -2,6 +2,7 @@
 # https://github.com/jwadhams/json-logic-js
 
 import sys
+from six.moves import reduce
 
 def jsonLogic(tests, data=None):
   # You've recursed to a primitive, stop!

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=[],
+    install_requires=['six'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
Problem was that dict.keys() returns an iterator on python3 and a list
on python2. Explicitly convert to list.
