### PR TITLE
Compatability with current JS verision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+.idea
+venv

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 install: pip install tox-travis
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 install: pip install tox-travis
 script: tox

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+release: build
+	python setup.py bdist_wheel upload -r local
+
+build: clean
+	python setup.py bdist_wheel
+
+clean:
+	rm -rf build dist json_logic_qubit.egg-info

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,5 @@
-release: build
+release:
 	python setup.py bdist_wheel upload -r local
-
-build: clean
-	python setup.py bdist_wheel
 
 clean:
 	rm -rf build dist json_logic_qubit.egg-info

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 release:
-	python setup.py bdist_wheel upload -r local
+	python setup.py bdist_wheel upload
 
 clean:
 	rm -rf build dist json_logic_qubit.egg-info

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # json-logic-py
+**NOTE:** This is fork of unmaintained [json-logic-py](https://github.com/nadirizr/json-logic-py)
 
+## Installation
+
+The best way to install this library is via [PIP](https://pypi.python.org/pypi/):
+
+```bash
+pip install json-logic-qubit
+```
+## Introduction
 This parser accepts [JsonLogic](http://jsonlogic.com) rules and executes them in Python.
 
 This is a Python porting of the excellent GitHub project by [jwadhams](https://github.com/jwadhams) for JavaScript: [json-logic-js](https://github.com/jwadhams/json-logic-js).
@@ -101,18 +110,4 @@ jsonLogic(True, data_will_be_ignored);
 #Never
 jsonLogic(False, i_wasnt_even_supposed_to_be_here);
 # False
-```
-
-## Installation
-
-The best way to install this library is via [PIP](https://pypi.python.org/pypi/):
-
-```bash
-pip install json-logic
-```
-
-If that doesn't suit you, and you want to manage updates yourself, the entire library is self-contained in `json_logic.py` and you can download it straight into your project as you see fit.
-
-```bash
-curl -O https://raw.githubusercontent.com/nadirizr/json-logic-py/master/json_logic.py
 ```

--- a/README.rst
+++ b/README.rst
@@ -143,13 +143,4 @@ The best way to install this library is via
 
 .. code:: bash
 
-    pip install json-logic
-
-If that doesn't suit you, and you want to manage updates yourself, the
-entire library is self-contained in ``json_logic.py`` and you can
-download it straight into your project as you see fit.
-
-.. code:: bash
-
-    curl -O https://raw.githubusercontent.com/nadirizr/json-logic-py/master/json_logic.py
-
+    pip install json-logic-qubit

--- a/json_logic/__init__.py
+++ b/json_logic/__init__.py
@@ -410,14 +410,11 @@ def jsonLogic(logic, data=None):
         return list(map(lambda subset: jsonLogic(subset, data), logic))
 
     # You've recursed to a primitive, stop!
-    if logic is None or not isinstance(logic, dict):
+    if not is_logic(logic):
         return logic
 
     # Get operator
-    operators = list(logic.keys())
-    if len(operators) != 1:
-        raise ValueError("Each rule must only contain a single operator.")
-    operator = operators[0]
+    operator = next(iter(logic.keys()))
 
     # Get values
     values = logic[operator]
@@ -455,3 +452,12 @@ def jsonLogic(logic, data=None):
 
     # Report unrecognized operation
     raise ValueError("Unrecognized operation %r" % operator)
+
+
+def is_logic(logic):
+    """
+    Determine if specified entry is a logic entry or not.
+    A logic entry is a dictionary with exactly one key.
+    An array of logic entries is not considered a logic entry itself.
+    """
+    return isinstance(logic, dict) and len(logic.keys()) == 1

--- a/json_logic/__init__.py
+++ b/json_logic/__init__.py
@@ -6,12 +6,8 @@ https://github.com/jwadhams/json-logic-js
 
 # Python 2 fallbacks
 from __future__ import division, unicode_literals
-try:
-    str = unicode
-except NameError:
-    pass
 from six.moves import reduce
-from six import integer_types
+from six import text_type, integer_types, advance_iterator
 numeric_types = integer_types + (float,)
 
 import logging
@@ -51,7 +47,7 @@ def _is_boolean(arg):
 
 def _is_string(arg):
     """Check if argument is a string."""
-    return isinstance(arg, str)
+    return isinstance(arg, text_type)
 
 
 def _is_numeric(arg):
@@ -73,7 +69,7 @@ def _to_numeric(arg):
 
 def _get_operator(logic):
     """Return operator name from JsonLogic rule."""
-    return str(next(iter(logic.keys())))
+    return text_type(advance_iterator(iter(logic.keys())))
 
 
 def _get_values(logic, operator, normalize=True):
@@ -104,7 +100,7 @@ def _expose_operations():
 def _equal_to(a, b):
     """Check for non-strict equality ('==') with JS-style type coercion."""
     if _is_string(a) or _is_string(b):
-        return str(a) == str(b)
+        return text_type(a) == text_type(b)
     if _is_boolean(a) or _is_boolean(b):
         return bool(a) is bool(b)
     return a == b
@@ -203,7 +199,7 @@ def _in(a, b):
 
 def _concatenate(*args):
     """Concatenate string elements into a single string."""
-    return "".join(str(arg) for arg in args)
+    return "".join(text_type(arg) for arg in args)
 
 
 def _substring(source, start, length=None):
@@ -303,7 +299,7 @@ def _method(obj, method, args=[]):
     gets datetime.date object from 'today' variable and returns the number of
     the month via 'month' property.
     """
-    method = getattr(obj, str(method))
+    method = getattr(obj, text_type(method))
     if callable(method):
         return method(*args)
     return method
@@ -696,7 +692,7 @@ def _var(data, var_name=None, default=None):
     if var_name is None or var_name == '':
         return data  # Return the whole data object
     try:
-        for key in str(var_name).split('.'):
+        for key in text_type(var_name).split('.'):
             try:
                 data = data[key]
             except TypeError:
@@ -966,14 +962,14 @@ def add_operation(name, code):
     but not logical, scoped or data retrieval ones.
     """
     global _custom_operations
-    _custom_operations[str(name)] = code
+    _custom_operations[text_type(name)] = code
     _expose_operations()
 
 
 def rm_operation(name):
     """Remove previously added custom common JsonLogic operation."""
     global _custom_operations
-    del(_custom_operations[str(name)])
+    del(_custom_operations[text_type(name)])
     _expose_operations()
 
 

--- a/json_logic/__init__.py
+++ b/json_logic/__init__.py
@@ -70,12 +70,12 @@ def _to_numeric(arg):
 
 
 def _get_operator(logic):
-    """Return operator name from JsonLogic entry."""
+    """Return operator name from JsonLogic rule."""
     return str(next(iter(logic.keys())))
 
 
 def _get_values(logic, operator, normalize=True):
-    """Return array of values from JsonLogic entry by operator name."""
+    """Return array of values from JsonLogic rule by operator name."""
     values = logic[operator]
     # Easy syntax for unary operators like {"var": "x"}
     # instead of strict {"var": ["x"]}
@@ -111,6 +111,7 @@ def _equal_to(a, b):
 def _strict_equal_to(a, b):
     """
     Check for strict equality ('===') including type equality.
+
     N.B.: Core JsonLogic does not differentiate between different numeric
     types and considers them strictly equal to each other.
     E.g.: {"===": [1, 1.0]}
@@ -440,13 +441,13 @@ def _filter(data, scopedData, scopedLogic):
 
     'scopedData' argument can be:
       - a manually specified data array;
-      - a JsonLogic entry returning a data array;
+      - a JsonLogic rule returning a data array;
       - a JsonLogic 'var' operation returning part of the data object
         containing a data array; like: {"var": "a"};
       - a JsonLogic 'var' operation returning the whole data object
         if it is an array itself; like: {"var": ""}.
 
-    'scopedLogic' is a normal JsonLogic entry that uses a 'scopeData'
+    'scopedLogic' is a normal JsonLogic rule that uses a 'scopeData'
     element as its data object.
 
     'scopedLogic' must evaluate to a truthy value in order for the current
@@ -477,13 +478,13 @@ def _map(data, scopedData, scopedLogic):
 
     'scopedData' argument can be:
       - a manually specified data array;
-      - a JsonLogic entry returning a data array;
+      - a JsonLogic rule returning a data array;
       - a JsonLogic 'var' operation returning part of the data object
         containing a data array; like: {"var": "a"};
       - a JsonLogic 'var' operation returning the whole data object
         if it is an array itself; like: {"var": ""}.
 
-    'scopedLogic' is a normal JsonLogic entry that uses a 'scopeData'
+    'scopedLogic' is a normal JsonLogic rule that uses a 'scopeData'
     element as its data object.
 
     Result returned by 'scopedLogic' is included into the resulting array.
@@ -515,13 +516,13 @@ def _reduce(data, scopedData, scopedLogic, initial=None):
 
     'scopedData' argument can be:
       - a manually specified data array;
-      - a JsonLogic entry returning a data array;
+      - a JsonLogic rule returning a data array;
       - a JsonLogic 'var' operation returning part of the data object
         containing a data array; like: {"var": "a"};
       - a JsonLogic 'var' operation returning the whole data object
         if it is an array itself; like: {"var": ""}.
 
-    'scopedLogic' is a normal JsonLogic entry that is applied to the following
+    'scopedLogic' is a normal JsonLogic rule that is applied to the following
     data object: {'accumulator': accumulator, 'current': current}; where
     'accumulator' is the result of all previous iterations (of 'initial' if
     none had occurred so far), and 'current' is the value of the current
@@ -557,13 +558,13 @@ def _all(data, scopedData, scopedLogic):
 
     'scopedData' argument can be:
       - a manually specified data array;
-      - a JsonLogic entry returning a data array;
+      - a JsonLogic rule returning a data array;
       - a JsonLogic 'var' operation returning part of the data object
         containing a data array; like: {"var": "a"};
       - a JsonLogic 'var' operation returning the whole data object
         if it is an array itself; like: {"var": ""}.
 
-    'scopedLogic' is a normal JsonLogic entry that uses a 'scopeData'
+    'scopedLogic' is a normal JsonLogic rule that uses a 'scopeData'
     element as its data object.
 
     Return True if 'scopedLogic' evaluates to a truthy value for all
@@ -600,13 +601,13 @@ def _none(data, scopedData, scopedLogic):
 
     'scopedData' argument can be:
       - a manually specified data array;
-      - a JsonLogic entry returning a data array;
+      - a JsonLogic rule returning a data array;
       - a JsonLogic 'var' operation returning part of the data object
         containing a data array; like: {"var": "a"};
       - a JsonLogic 'var' operation returning the whole data object
         if it is an array itself; like: {"var": ""}.
 
-    'scopedLogic' is a normal JsonLogic entry that uses a 'scopeData'
+    'scopedLogic' is a normal JsonLogic rule that uses a 'scopeData'
     element as its data object.
 
     Return True if 'scopedLogic' evaluates to a falsy value for all
@@ -636,13 +637,13 @@ def _some(data, scopedData, scopedLogic):
 
     'scopedData' argument can be:
       - a manually specified data array;
-      - a JsonLogic entry returning a data array;
+      - a JsonLogic rule returning a data array;
       - a JsonLogic 'var' operation returning part of the data object
         containing a data array; like: {"var": "a"};
       - a JsonLogic 'var' operation returning the whole data object
         if it is an array itself; like: {"var": ""}.
 
-    'scopedLogic' is a normal JsonLogic entry that uses a 'scopeData'
+    'scopedLogic' is a normal JsonLogic rule that uses a 'scopeData'
     element as its data object.
 
     Return True if 'scopedLogic' evaluates to a truthy value for at least
@@ -682,10 +683,10 @@ def _var(data, var_name=None, default=None):
     Get variable value from the data object.
     Can also access variable properties (to any depth) via dot-notation:
         "variable.property"
-        "variable.property.sub_property"
+        "variable.property.subproperty"
     The same is true for array elements that can be accessed by index:
         "array_variable.5"
-        "variable.array_property.0.sub_property"
+        "variable.array_property.0.subproperty"
     Return the specified default value if variable, its property or element
     is not found. Return None if no default value is specified.
     Return the whole data object if variable name is None or an empty string.
@@ -762,14 +763,14 @@ _data_operations = {
 def jsonLogic(logic, data=None):
     """
     Evaluate provided JsonLogic using given data (if any).
-    If a single JsonLogic entry is provided - return a single resulting value.
-    If an array of JsonLogic entries is provided - return an array of each
-    entry's resulting values.
+    If a single JsonLogic rule is provided - return a single resulting value.
+    If an array of JsonLogic rule is provided - return an array of each rule's
+    resulting values.
     """
 
-    # Is this an array of JsonLogic entries?
+    # Is this an array of JsonLogic rules?
     if _is_array(logic):
-        return list(map(lambda subset: jsonLogic(subset, data), logic))
+        return list(map(lambda sublogic: jsonLogic(sublogic, data), logic))
 
     # You've recursed to a primitive, stop!
     if not is_logic(logic):
@@ -844,18 +845,19 @@ def jsonLogic(logic, data=None):
 
 def is_logic(logic):
     """
-    Determine if specified entry is a logic entry or not.
-    A logic entry is a dictionary with exactly one key.
-    An array of logic entries is not considered a logic entry itself.
+    Determine if specified object is a JsonLogic rule or not.
+    A JsonLogic rule is a dictionary with exactly one key.
+    An array of JsonLogic rules is not considered a rule itself.
     """
     return _is_dictionary(logic) and len(logic.keys()) == 1
 
 
 def uses_data(logic):
     """
-    Return a unique array of variables used in JsonLogic entry.
+    Return a unique array of variables used in JsonLogic rule.
+
     N.B.: It does not cover the case where the argument to 'var'
-    is itself a JsonLogic entry.
+    is itself a JsonLogic rule.
     """
     variables = set()
     if is_logic(logic):
@@ -870,9 +872,9 @@ def uses_data(logic):
 
 def rule_like(rule, pattern):
     """
-    Check if JsonLogic entry matches a certain 'pattern'.
-    Pattern follows the same structure as a normal JsonLogic entry with
-    the following extensions:
+    Check if JsonLogic rule matches a certain 'pattern'.
+    Pattern follows the same structure as a normal JsonLogic rule
+    with the following extensions:
       - '@' element matches anything:
         1 == '@'
         "jsonlogic" == '@'
@@ -894,7 +896,7 @@ def rule_like(rule, pattern):
         [] == 'array'
         [1, 2, 3] = 'array'
         {'+': [1, 2]} == {'+': 'array'}
-    Use this method to make sure JsonLogic element is correctly constructed.
+    Use this method to make sure JsonLogic rule is correctly constructed.
     """
     if pattern == rule:
         return True
@@ -909,7 +911,7 @@ def rule_like(rule, pattern):
 
     if is_logic(pattern):
         if is_logic(rule):
-            # Both pattern and rule are JsonLogic entries, go deeper
+            # Both pattern and rule are a valid JsonLogic rule, go deeper
             pattern_operator = _get_operator(pattern)
             rule_operator = _get_operator(rule)
             if pattern_operator == '@' or pattern_operator == rule_operator:

--- a/json_logic/__init__.py
+++ b/json_logic/__init__.py
@@ -139,6 +139,20 @@ def _concatenate(*args):
     return "".join(str(arg) for arg in args)
 
 
+def _substring(source, start, length=None):
+    """
+    Return part of 'source' string specified by 'start' and 'length' arguments.
+    Positive 'start': start at a specified position in the string.
+    Negative 'start': start at a specified position from the end of the string.
+    Zero 'start': start at the first character in the string.
+    Positive 'length': max length to be returned from the 'start'.
+    Negative 'length': max length to be omitted from the end of the string.
+    Zero 'length': return empty string.
+    Omitted 'length': return part from the 'start' till the end of the string.
+    """
+    return source[start:][:length]
+
+
 def _add(*args):
     """Sum up all arguments converting them to either integers or floats."""
     result = sum(_to_numeric(arg) for arg in args)
@@ -215,6 +229,7 @@ operations = {
     'log': _log,
     'in': _in,
     'cat': _concatenate,
+    'substr': _substring,
     '+': _add,
     '-': _subtract,
     '*': _multiply,

--- a/json_logic/__init__.py
+++ b/json_logic/__init__.py
@@ -2,19 +2,16 @@
 # https://github.com/jwadhams/json-logic-js
 from __future__ import unicode_literals
 
-import sys
 from six.moves import reduce
 import logging
 
 logger = logging.getLogger(__name__)
 
+# Python 2 fallback
 try:
-    unicode
+    str = unicode
 except NameError:
     pass
-else:
-    # Python 2 fallback.
-    str = unicode
 
 
 def if_(*args):
@@ -29,7 +26,7 @@ def if_(*args):
 
 
 def soft_equals(a, b):
-    """Implements the '==' operator, which does type JS-style coertion."""
+    """Implements the '==' operator, which does type JS-style coercion."""
     if isinstance(a, str) or isinstance(b, str):
         return str(a) == str(b)
     if isinstance(a, bool) or isinstance(b, bool):
@@ -45,7 +42,7 @@ def hard_equals(a, b):
 
 
 def less(a, b, *args):
-    """Implements the '<' operator with JS-style type coertion."""
+    """Implements the '<' operator with JS-style type coercion."""
     types = set([type(a), type(b)])
     if float in types or int in types:
         try:
@@ -57,7 +54,7 @@ def less(a, b, *args):
 
 
 def less_or_equal(a, b, *args):
-    """Implements the '<=' operator with JS-style type coertion."""
+    """Implements the '<=' operator with JS-style type coercion."""
     return (
         less(a, b) or soft_equals(a, b)
     ) and (not args or less_or_equal(b, *args))
@@ -74,6 +71,7 @@ def to_numeric(arg):
         else:
             return int(arg)
     return arg
+
 
 def plus(*args):
     """Sum converts either to ints or to floats."""
@@ -182,8 +180,8 @@ def jsonLogic(tests, data=None):
     operator = list(tests.keys())[0]
     values = tests[operator]
 
-    # Easy syntax for unary operators, like {"var": "x"} instead of strict
-    # {"var": ["x"]}
+    # Easy syntax for unary operators, like {"var": "x"}
+    # instead of strict {"var": ["x"]}
     if not isinstance(values, list) and not isinstance(values, tuple):
         values = [values]
 

--- a/json_logic/__init__.py
+++ b/json_logic/__init__.py
@@ -3,11 +3,12 @@ This is a Python implementation of the JsonLogic JS library:
 https://github.com/jwadhams/json-logic-js
 """
 
-
 # Python 2 fallbacks
 from __future__ import division, unicode_literals
-from six.moves import reduce
+
 from six import text_type, integer_types, advance_iterator
+from six.moves import reduce
+
 numeric_types = integer_types + (float,)
 
 import logging
@@ -95,6 +96,15 @@ def _expose_operations():
     return operations
 
 
+def _not_none(fn):
+    def wrapped(*args):
+        if len(args) > 1 and all([arg is None for arg in args]):
+            return False
+        return fn(*args)
+
+    return wrapped
+
+
 # Common operations
 
 def _equal_to(a, b):
@@ -131,6 +141,7 @@ def _not_strict_equal_to(a, b):
     return not _strict_equal_to(a, b)
 
 
+@_not_none
 def _less_than(a, b, c=_no_argument):
     """
     Check that A is less then B (A < B) or
@@ -149,6 +160,7 @@ def _less_than(a, b, c=_no_argument):
     return a < b and (c is _no_argument or _less_than(b, c))
 
 
+@_not_none
 def _less_than_or_equal_to(a, b, c=_no_argument):
     """
     Check that A is less then or equal to B (A <= B) or
@@ -164,11 +176,13 @@ def _less_than_or_equal_to(a, b, c=_no_argument):
         (c is _no_argument or _less_than_or_equal_to(b, c))
 
 
+@_not_none
 def _greater_than(a, b):
     """Check that A is greater then B (A > B)."""
     return _less_than(b, a)
 
 
+@_not_none
 def _greater_than_or_equal_to(a, b):
     """Check that A is greater then or equal to B (A >= B)."""
     return _less_than_or_equal_to(b, a)
@@ -342,7 +356,6 @@ def _count(*args):
 _unsupported_operations = {
     'count': _count
 }
-
 
 # Custom operation (may be added manually)
 
@@ -969,7 +982,7 @@ def add_operation(name, code):
 def rm_operation(name):
     """Remove previously added custom common JsonLogic operation."""
     global _custom_operations
-    del(_custom_operations[text_type(name)])
+    del (_custom_operations[text_type(name)])
     _expose_operations()
 
 

--- a/json_logic/__init__.py
+++ b/json_logic/__init__.py
@@ -272,6 +272,14 @@ def _if(data, *args):
         return None
 
 
+def _iif(data, a, b, c):
+    """
+    Evaluate ternary expression and return corresponding evaluated
+    argument based on the following pattern: if (A) then {B} else {C}
+    """
+    return _if(data, a, b, c)
+
+
 def _and(data, *args):
     """
     Evaluate and logically join arguments using the 'and' operator.
@@ -306,6 +314,7 @@ def _or(data, *args):
 
 logical_operations = {
     'if': _if,
+    '?:': _iif,
     'and': _and,
     'or': _or,
 }

--- a/json_logic/__init__.py
+++ b/json_logic/__init__.py
@@ -20,6 +20,8 @@ import warnings
 __all__ = (
     'jsonLogic',
     'is_logic',
+    'uses_data',
+    'rule_like',
     'operations',
     'add_operation',
     'rm_operation'

--- a/json_logic/__init__.py
+++ b/json_logic/__init__.py
@@ -1,32 +1,51 @@
-# This is a Python implementation of the following jsonLogic JS library:
-# https://github.com/jwadhams/json-logic-js
-from __future__ import unicode_literals
+"""
+This is a Python implementation of the JsonLogic JS library:
+https://github.com/jwadhams/json-logic-js
+"""
 
-from six.moves import reduce
-import logging
 
-logger = logging.getLogger(__name__)
-
-# Python 2 fallback
+# Python 2 fallbacks
+from __future__ import division, unicode_literals
 try:
     str = unicode
 except NameError:
     pass
+from six.moves import reduce
+from six import integer_types
+numeric_types = integer_types + (float,)
+
+import logging
+import warnings
 
 
-def if_(*args):
-    """Implements the 'if' operator with support for multiple elseif-s."""
-    for i in range(0, len(args) - 1, 2):
-        if args[i]:
-            return args[i + 1]
-    if len(args) % 2:
-        return args[-1]
-    else:
-        return None
+# Helper functions and variables
+
+# Sentinel value to indicate an optional argument
+# that can take various values including None
+_no_argument = object()
 
 
-def soft_equals(a, b):
-    """Implements the '==' operator, which does type JS-style coercion."""
+def _is_numeric(arg):
+    """Check if argument is of a numeric type: float, int or long."""
+    return type(arg) in numeric_types
+
+
+def _to_numeric(arg):
+    """
+    Convert a string or other value  into float, integer or long.
+    Convert float value to integer if appropriate.
+    """
+    if isinstance(arg, str) and '.' in arg:
+        arg = float(arg)
+    if isinstance(arg, float):
+        return int(arg) if arg.is_integer() else arg
+    return int(arg)
+
+
+# Common operations
+
+def _equal_to(a, b):
+    """Test for non-strict equality ('==') with JS-style type coercion."""
     if isinstance(a, str) or isinstance(b, str):
         return str(a) == str(b)
     if isinstance(a, bool) or isinstance(b, bool):
@@ -34,70 +53,281 @@ def soft_equals(a, b):
     return a == b
 
 
-def hard_equals(a, b):
-    """Implements the '===' operator."""
-    if type(a) != type(b):
-        return False
-    return a == b
+def _strict_equal_to(a, b):
+    """
+    Check for strict equality ('===') including type equality.
+    N.B.: Core JsonLogic does not differentiate between different numeric
+    types and considers them strictly equal to each other.
+    E.g.: {"===": [1, 1.0]}
+    """
+    if type(a) is type(b):
+        return a == b
+    if _is_numeric(a) and _is_numeric(b):
+        return _to_numeric(a) == _to_numeric(b)
+    return False
 
 
-def less(a, b, *args):
-    """Implements the '<' operator with JS-style type coercion."""
+def _not_equal_to(a, b):
+    """Check for non-strict inequality ('==') with JS-style type coercion."""
+    return not _equal_to(a, b)
+
+
+def _not_strict_equal_to(a, b):
+    """Check for strict inequality ('!==') including type inequality."""
+    return not _strict_equal_to(a, b)
+
+
+def _less_than(a, b, c=_no_argument):
+    """
+    Check that A is less then B (A < B) or
+    that B is exclusively between A and C (A < B < C).
+    """
     types = set([type(a), type(b)])
     if float in types or int in types:
         try:
             a, b = float(a), float(b)
         except TypeError:
-            # NaN
-            return False
-    return a < b and (not args or less(b, *args))
+            return False  # NaN
+    return a < b and (c is _no_argument or _less_than(b, c))
 
 
-def less_or_equal(a, b, *args):
-    """Implements the '<=' operator with JS-style type coercion."""
-    return (
-        less(a, b) or soft_equals(a, b)
-    ) and (not args or less_or_equal(b, *args))
-
-
-def to_numeric(arg):
+def _less_than_or_equal_to(a, b, c=_no_argument):
     """
-    Converts a string either to int or to float.
-    This is important, because e.g. {"!==": [{"+": "0"}, 0.0]}
+    Check that A is less then or equal to B (A <= B) or
+    that B is inclusively between A and C (A <= B <= C).
     """
-    if isinstance(arg, str):
-        if '.' in arg:
-            return float(arg)
-        else:
-            return int(arg)
-    return arg
+    return \
+        (_less_than(a, b) or _equal_to(a, b)) and \
+        (c is _no_argument or _less_than_or_equal_to(b, c))
 
 
-def plus(*args):
-    """Sum converts either to ints or to floats."""
-    return sum(to_numeric(arg) for arg in args)
+def _greater_than(a, b):
+    """Check that A is greater then B (A > B)."""
+    return _less_than(b, a)
 
 
-def minus(*args):
-    """Also, converts either to ints or to floats."""
-    if len(args) == 1:
-        return -to_numeric(args[0])
-    return to_numeric(args[0]) - to_numeric(args[1])
+def _greater_than_or_equal_to(a, b):
+    """Check that A is greater then or equal to B (A >= B)."""
+    return _less_than_or_equal_to(b, a)
 
 
-def merge(*args):
-    """Implements the 'merge' operator for merging lists."""
-    ret = []
+def _truthy(a):
+    """Check that argument evaluates to True according to core JsonLogic."""
+    return bool(a)
+
+
+def _falsy(a):
+    """Check that argument evaluates to False according to core JsonLogic."""
+    return not _truthy(a)
+
+
+def _log(a):
+    """Log data to 'logging' module at INFO level."""
+    logging.getLogger(__name__).info(a)
+    return a
+
+
+def _in(a, b):
+    """Check that A is in B according to core JsonLogic."""
+    if hasattr(b, '__contains__'):
+        return a in b
+    return False
+
+
+def _concatenate(*args):
+    """Concatenate string elements into a single string."""
+    return "".join(str(arg) for arg in args)
+
+
+def _add(*args):
+    """Sum up all arguments converting them to either integers or floats."""
+    result = sum(_to_numeric(arg) for arg in args)
+    return _to_numeric(result)
+
+
+def _subtract(a, b=_no_argument):
+    """
+    Subtract B from A converting them to either integers or floats.
+    If only A is provided - return its arithmetic negative.
+    """
+    if b is _no_argument:
+        result = -_to_numeric(a)
+    else:
+        result = _to_numeric(a) - _to_numeric(b)
+    return _to_numeric(result)
+
+
+def _multiply(*args):
+    """Multiply all arguments converting them to either integers or floats."""
+    result = reduce(lambda total, arg: total * _to_numeric(arg), args, 1)
+    return _to_numeric(result)
+
+
+def _divide(a, b):
+    """
+    Divide A by B converting them to either integers or floats.
+    """
+    result = _to_numeric(a) / _to_numeric(b)
+    return _to_numeric(result)
+
+
+def _modulo(a, b):
+    """
+    Get modulo after division of A by B
+    (converted to either integers or floats).
+    """
+    result = _to_numeric(a) % _to_numeric(b)
+    return _to_numeric(result)
+
+
+def _minimal(*args):
+    """Get minimal value among provided arguments."""
+    return min(_to_numeric(arg) for arg in args) if args else None
+
+
+def _maximal(*args):
+    """Get maximal value among provided arguments."""
+    return max(_to_numeric(arg) for arg in args) if args else None
+
+
+def _merge(*args):
+    """Merge several arrays into one."""
+    resulting_array = []
     for arg in args:
-        if isinstance(arg, list) or isinstance(arg, tuple):
-            ret += list(arg)
+        if isinstance(arg, (list, tuple)):
+            resulting_array.extend(arg)
         else:
-            ret.append(arg)
-    return ret
+            resulting_array.append(arg)
+    return resulting_array
 
 
-def get_var(data, var_name, not_found=None):
-    """Gets variable value from data dictionary."""
+operations = {
+    '==': _equal_to,
+    '===': _strict_equal_to,
+    '!=': _not_equal_to,
+    '!==': _not_strict_equal_to,
+    '>': _greater_than,
+    '>=': _greater_than_or_equal_to,
+    '<': _less_than,
+    '<=': _less_than_or_equal_to,
+    '!!': _truthy,
+    '!': _falsy,
+    'log': _log,
+    'in': _in,
+    'cat': _concatenate,
+    '+': _add,
+    '-': _subtract,
+    '*': _multiply,
+    '/': _divide,
+    '%': _modulo,
+    'min': _minimal,
+    'max': _maximal,
+    'merge': _merge,
+}
+
+
+# Unsupported operations
+
+def _count(*args):
+    """Execute 'count' operation unsupported by core JsonLogic."""
+    return sum(1 if a else 0 for a in args)
+
+
+unsupported_operations = {
+    'count': _count
+}
+
+
+# Logical operations
+
+def _if(data, *args):
+    """
+    Evaluate chainable conditions with multiple 'else if' support and return
+    the corresponding evaluated argument based on the following patterns:
+
+    if 0 then 1 else None
+    if 0 then 1 else 2
+    if 0 then 1 else if 2 then 3 else 4
+    if 0 then 1 else if 2 then 3 else if 4 then 5 else 6
+
+    - If no arguments are given then return None.
+    - If only one argument is given the evaluate and return it.
+    - If two arguments are given then evaluate the first one, if it evaluates
+      to True return evaluated second argument, otherwise return None.
+    - If three arguments are given then evaluate the first one, if it evaluates
+      to True return evaluated second argument, otherwise return evaluated
+      third argument.
+    - For more then 3 arguments:
+        - If the first argument evaluates to True then evaluate and return
+          the second argument.
+        - If the first argument evaluates to False then jump to the next pair
+          (e.g.: from 0,1 to 2,3) and evaluate them.
+    """
+    for i in range(0, len(args) - 1, 2):
+        if _truthy(jsonLogic(args[i], data)):
+            return jsonLogic(args[i + 1], data)
+    if len(args) % 2:
+        return jsonLogic(args[-1], data)
+    else:
+        return None
+
+
+def _and(data, *args):
+    """
+    Evaluate and logically join arguments using the 'and' operator.
+    If all arguments evaluate to True return the last (truthy) one (meaning
+    that the whole expression evaluates to True).
+    Otherwise return first countered falsy argument (meaning that the whole
+    expression evaluates to False).
+    """
+    current = False
+    for current in args:
+        current = jsonLogic(current, data)
+        if _falsy(current):
+            return current  # First falsy argument
+    return current  # Last argument
+
+
+def _or(data, *args):
+    """
+    Evaluate and logically join arguments using the 'or' operator.
+    If at least one argument evaluates to True - return it
+    (meaning that the whole expression evaluates to True).
+    Otherwise return the last (falsy) argument (meaning that the whole
+    expression evaluates to False).
+    """
+    current = False
+    for current in args:
+        current = jsonLogic(current, data)
+        if _truthy(current):
+            return current  # First truthy argument
+    return current  # Last argument
+
+
+logical_operations = {
+    'if': _if,
+    'and': _and,
+    'or': _or,
+}
+
+
+# Data operations
+
+def _var(data, var_name=None, default=None):
+    """
+    Get variable value from the data object.
+    Can also access variable properties (to any depth) via dot-notation:
+        "variable.property"
+        "variable.property.sub_property"
+    The same is true for array elements that can be accessed by index:
+        "array_variable.5"
+        "variable.array_property.0.sub_property"
+    Return the specified default value if variable, its property or element
+    is not found. Return None if no default value is specified.
+    Return the whole data object if variable name is None or an empty string.
+    """
+    if var_name is None or var_name == '':
+        return data  # Return the whole data object
     try:
         for key in str(var_name).split('.'):
             try:
@@ -105,97 +335,123 @@ def get_var(data, var_name, not_found=None):
             except TypeError:
                 data = data[int(key)]
     except (KeyError, TypeError, ValueError):
-        return not_found
+        return default
     else:
         return data
 
 
-def missing(data, *args):
-    """Implements the missing operator for finding missing variables."""
-    not_found = object()
-    if args and isinstance(args[0], list):
-        args = args[0]
-    ret = []
-    for arg in args:
-        if get_var(data, arg, not_found) is not_found:
-            ret.append(arg)
-    return ret
+def _missing(data, *args):
+    """
+    Check if one or more variables are missing from data object.
+    Take either:
+      - multiple arguments (one variable name per argument) like:
+        {"missing:["variable_1", "variable_2"]}.
+      - a single argument that is an array of variable names like:
+        {"missing": [["variable_1", "variable_2"]] (this typically happens
+        if this operator is applied to the output of another operator
+        (like 'if' or 'merge').
+    Return an empty array if all variables are present and non-empty.
+    Otherwise return a array of all missing variable names.
+
+    N.B.: Per core JsonLogic, if missing variable name is provided several
+    times it will also be represented several times in the resulting array.
+    """
+    missing_array = []
+    var_names = \
+        args[0] if args and isinstance(args[0], (list, tuple)) \
+        else args
+    for var_name in var_names:
+        if _var(data, var_name) in (None, ""):
+            missing_array.append(var_name)
+    return missing_array
 
 
-def missing_some(data, min_required, args):
-    """Implements the missing_some operator for finding missing variables."""
-    if min_required < 1:
+def _missing_some(data, need_count, args):
+    """
+    Check if at least some of the variables are missing from data object.
+    Take two arguments:
+      - minimum number of variables that are required to be present.
+      - array of variable names to check for.
+    I.e.: "{"missing_some":[1, ["a", "b", "c"]]}" means that at least one of
+    the provided "a", "b" and "c" variables must be present in the data object.
+    Return an empty array if minimum number of present variables is met.
+    Otherwise return an array of all missing variable names.
+
+    N.B.: Per core JsonLogic, if missing variable name is provided several
+    times it will also be represented several times in the resulting array.
+    In that case all occurrences are counted towards the minimum number of
+    variables to be present and may lead to unexpected results.
+    """
+    missing_array = _missing(data, args)
+    if len(args) - len(missing_array) >= need_count:
         return []
-    found = 0
-    not_found = object()
-    ret = []
-    for arg in args:
-        if get_var(data, arg, not_found) is not_found:
-            ret.append(arg)
-        else:
-            found += 1
-            if found >= min_required:
-                return []
-    return ret
+    return missing_array
 
 
-operations = {
-    "==": soft_equals,
-    "===": hard_equals,
-    "!=": lambda a, b: not soft_equals(a, b),
-    "!==": lambda a, b: not hard_equals(a, b),
-    ">": lambda a, b: less(b, a),
-    ">=": lambda a, b: less(b, a) or soft_equals(a, b),
-    "<": less,
-    "<=": less_or_equal,
-    "!": lambda a: not a,
-    "!!": bool,
-    "%": lambda a, b: a % b,
-    "and": lambda *args: reduce(lambda total, arg: total and arg, args, True),
-    "or": lambda *args: reduce(lambda total, arg: total or arg, args, False),
-    "?:": lambda a, b, c: b if a else c,
-    "if": if_,
-    "log": lambda a: logger.info(a) or a,
-    "in": lambda a, b: a in b if "__contains__" in dir(b) else False,
-    "cat": lambda *args: "".join(str(arg) for arg in args),
-    "+": plus,
-    "*": lambda *args: reduce(lambda total, arg: total * float(arg), args, 1),
-    "-": minus,
-    "/": lambda a, b=None: a if b is None else float(a) / float(b),
-    "min": lambda *args: min(args),
-    "max": lambda *args: max(args),
-    "merge": merge,
-    "count": lambda *args: sum(1 if a else 0 for a in args),
+data_operations = {
+    'var': _var,
+    'missing': _missing,
+    'missing_some': _missing_some
 }
 
 
-def jsonLogic(tests, data=None):
-    """Executes the json-logic with given data."""
-    # You've recursed to a primitive, stop!
-    if tests is None or not isinstance(tests, dict):
-        return tests
+# MAIN LOGIC
 
+def jsonLogic(logic, data=None):
+    """
+    Evaluate provided JsonLogic using given data (if any).
+    If a single JsonLogic entry is provided - return a single resulting value.
+    If an array of JsonLogic entries is provided - return an array of each
+    entry's resulting values.
+    """
+
+    # Is this an array of JsonLogic entries?
+    if isinstance(logic, (list, tuple)):
+        return list(map(lambda subset: jsonLogic(subset, data), logic))
+
+    # You've recursed to a primitive, stop!
+    if logic is None or not isinstance(logic, dict):
+        return logic
+
+    # Get operator
+    operators = list(logic.keys())
+    if len(operators) != 1:
+        raise ValueError("Each rule must only contain a single operator.")
+    operator = operators[0]
+
+    # Get values
+    values = logic[operator]
+    # Easy syntax for unary operators like {"var": "x"}
+    # instead of strict {"var": ["x"]}
+    if not isinstance(values, (list, tuple)):
+        values = [values]
+
+    # Get data
     data = data or {}
 
-    operator = list(tests.keys())[0]
-    values = tests[operator]
-
-    # Easy syntax for unary operators, like {"var": "x"}
-    # instead of strict {"var": ["x"]}
-    if not isinstance(values, list) and not isinstance(values, tuple):
-        values = [values]
+    # Try applying logical operators first as they violate the normal rule of
+    # depth-first calculating consequents. Let each manage recursion as needed.
+    if operator in logical_operations:
+        return logical_operations[operator](data, *values)
 
     # Recursion!
     values = [jsonLogic(val, data) for val in values]
 
-    if operator == 'var':
-        return get_var(data, *values)
-    if operator == 'missing':
-        return missing(data, *values)
-    if operator == 'missing_some':
-        return missing_some(data, *values)
+    # Apply data retrieval operations
+    if operator in data_operations:
+        return data_operations[operator](data, *values)
 
-    if operator not in operations:
-        raise ValueError("Unrecognized operation %s" % operator)
+    # Apply common operations
+    if operator in operations:
+        return operations[operator](*values)
 
-    return operations[operator](*values)
+    # Apply unsupported common operations if any
+    if operator in unsupported_operations:
+        warnings.warn(
+            ("%r operation is not officially supported by JsonLogic and " +
+             "is not guarantied to work in other JsonLogic ports") % operator,
+            PendingDeprecationWarning)
+        return unsupported_operations[operator](*values)
+
+    # Report unrecognized operation
+    raise ValueError("Unrecognized operation %r" % operator)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ pkginfo==1.2.1
 requests==2.8.1
 requests-toolbelt==0.5.0
 sh==1.11
+six==1.11.0
 twine==1.6.4
 wheel==0.26.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pandoc==1.0.0a8
+pandoc==1.0.0
 pkginfo==1.2.1
 requests==2.8.1
 requests-toolbelt==0.5.0

--- a/setup.py
+++ b/setup.py
@@ -18,12 +18,12 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(
-    name='json_logic',
+    name='json_logic_qubit',
 
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.7.0-alpha',
+    version='0.8',
 
     description=(
         'Build complex rules, serialize them as JSON, ' +

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,9 @@ setup(
     # https://packaging.python.org/en/latest/single_source_version.html
     version='0.7.0-alpha',
 
-    description='Build complex rules, serialize them as JSON, and execute them in Python',
+    description=(
+        'Build complex rules, serialize them as JSON, ' +
+        'and execute them in Python'),
     long_description=long_description,
 
     # The project's main homepage.
@@ -62,6 +64,8 @@ setup(
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 
     # What does your project relate to?

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ setup(
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.2',
@@ -66,6 +65,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 
     # What does your project relate to?

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     long_description=long_description,
 
     # The project's main homepage.
-    url='https://github.com/qubitdigital/json-logic-py',
+    url='https://github.com/qubitproducts/json-logic-py',
 
     # Author details
     author='mohsin.niazi',

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,8 @@ setup(
     url='https://github.com/qubitdigital/json-logic-py',
 
     # Author details
-    author='nadir.izr',
-    author_email='nadir@soundmindtech.com',
+    author='mohsin.niazi',
+    author_email='mohsin.niazi@qubit.com',
 
     # Choose your license
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.8',
+    version='0.9',
 
     description=(
         'Build complex rules, serialize them as JSON, ' +

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     long_description=long_description,
 
     # The project's main homepage.
-    url='https://github.com/nadirizr/json-logic-py',
+    url='https://github.com/qubitdigital/json-logic-py',
 
     # Author details
     author='nadir.izr',

--- a/tests.py
+++ b/tests.py
@@ -17,6 +17,7 @@ class JSONLogicTest(unittest.TestCase):
     The tests here come from 'Supported operations' page on jsonlogic.com:
     http://jsonlogic.com/operations.html
     """
+
     def test_var(self):
         """Retrieve data from the provided data object."""
         self.assertEqual(
@@ -368,12 +369,15 @@ class JSONLogicTest(unittest.TestCase):
 class SharedTests(unittest.TestCase):
     """This runs the tests from http://jsonlogic.com/tests.json."""
     cnt = 0
+
     @classmethod
     def create_test(cls, logic, data, expected):
         """Adds new test to the class."""
+
         def test(self):
             """Actual test function."""
             self.assertEqual(jsonLogic(logic, data), expected)
+
         test.__doc__ = "{},  {}  =>  {}".format(logic, data, expected)
         setattr(cls, "test_{}".format(cls.cnt), test)
         cls.cnt += 1

--- a/tests.py
+++ b/tests.py
@@ -2,15 +2,17 @@
 
 from __future__ import unicode_literals
 
-import six
+import datetime
 import json
 import logging
-import datetime
 import unittest
+
 try:
     from urllib.request import urlopen
 except ImportError:
+    # noinspection PyUnresolvedReferences
     from urllib2 import urlopen
+# noinspection PyUnresolvedReferences
 from json_logic import \
     jsonLogic, \
     is_logic, \
@@ -25,7 +27,6 @@ from json_logic import \
     _data_operations, \
     _common_operations, \
     _unsupported_operations
-
 
 # Python 2 fallback
 if not hasattr(unittest.TestCase, 'assertRaisesRegex'):
@@ -58,6 +59,7 @@ def shared_test(function, url):
     def create_test(cls, count, arg1, arg2, expected):
         def test(self):
             self.assertEqual(function(arg1, arg2), expected)
+
         test.__doc__ = "{},  {}  =>  {}".format(arg1, arg2, expected)
         setattr(cls, "test_{}".format(count), test)
 
@@ -222,7 +224,7 @@ class AdditionalJsonLogicTests(unittest.TestCase):
         logic = {'method': [{'var': 'today'}, 'isoformat']}
         data = {'today': todays_date}
         returned_value = jsonLogic(logic, data)
-        self.assertIsInstance(returned_value, str)#six.text_type)
+        self.assertIsInstance(returned_value, str)  # six.text_type)
         self.assertEqual(returned_value, todays_date.isoformat())
 
     def test_method_operation_with_method_with_arguments(self):
@@ -271,8 +273,8 @@ class AdditionalJsonLogicTests(unittest.TestCase):
         self.assertSequenceEqual(conditions, [True])
         self.assertSequenceEqual(consequents, ["first"])
 
-        del(conditions[:])
-        del(consequents[:])
+        del (conditions[:])
+        del (consequents[:])
 
         jsonLogic({'if': [
             {'push_if': [False]},
@@ -284,8 +286,8 @@ class AdditionalJsonLogicTests(unittest.TestCase):
         self.assertSequenceEqual(conditions, [False, True])
         self.assertSequenceEqual(consequents, ["second"])
 
-        del(conditions[:])
-        del(consequents[:])
+        del (conditions[:])
+        del (consequents[:])
 
         jsonLogic({'if': [
             {'push_if': [False]},
@@ -319,7 +321,7 @@ class AdditionalJsonLogicTests(unittest.TestCase):
         ]})
         self.assertSequenceEqual(consequents, ["first"])
 
-        del(consequents[:])
+        del (consequents[:])
 
         jsonLogic({'?:': [
             False,
@@ -341,12 +343,12 @@ class AdditionalJsonLogicTests(unittest.TestCase):
         jsonLogic({'and': [{'push': [False]}, {'push': [False]}]})
         self.assertSequenceEqual(evaluated_elements, [False])
 
-        del(evaluated_elements[:])
+        del (evaluated_elements[:])
 
         jsonLogic({'and': [{'push': [False]}, {'push': [True]}]})
         self.assertSequenceEqual(evaluated_elements, [False])
 
-        del(evaluated_elements[:])
+        del (evaluated_elements[:])
 
         jsonLogic({'and': [{'push': [True]}, {'push': [True]}]})
         self.assertSequenceEqual(evaluated_elements, [True, True])
@@ -364,17 +366,17 @@ class AdditionalJsonLogicTests(unittest.TestCase):
         jsonLogic({'or': [{'push': [False]}, {'push': [False]}]})
         self.assertSequenceEqual(evaluated_elements, [False, False])
 
-        del(evaluated_elements[:])
+        del (evaluated_elements[:])
 
         jsonLogic({'or': [{'push': [False]}, {'push': [True]}]})
         self.assertSequenceEqual(evaluated_elements, [False, True])
 
-        del(evaluated_elements[:])
+        del (evaluated_elements[:])
 
         jsonLogic({'or': [{'push': [True]}, {'push': [False]}]})
         self.assertSequenceEqual(evaluated_elements, [True])
 
-        del(evaluated_elements[:])
+        del (evaluated_elements[:])
 
         jsonLogic({'or': [{'push': [True]}, {'push': [True]}]})
         self.assertSequenceEqual(evaluated_elements, [True])
@@ -455,6 +457,7 @@ class AdditionalJsonLogicTests(unittest.TestCase):
     def test_add_operation_with_simple_method(self):
         def add_to_five(*args):
             return sum((5,) + args)
+
         self.assertRaisesRegex(
             ValueError, "Unrecognized operation",
             jsonLogic, {'add_to_five': [3]})
@@ -587,6 +590,16 @@ class AdditionalJsonLogicTests(unittest.TestCase):
             rm_operation('+')
         self.assertIn('+', operations)
         self.assertIsNot(operations['+'], haha)
+
+    def test_none_params(self):
+        self.assertFalse(jsonLogic({
+            'and': [
+                {'<': [None, None]},
+                {'<=': [None, None]},
+                {'>': [None, None]},
+                {'>=': [None, None]}
+            ]
+        }))
 
 
 if __name__ == '__main__':

--- a/tests.py
+++ b/tests.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 
+import six
 import json
 import logging
 import datetime
@@ -221,7 +222,7 @@ class AdditionalJsonLogicTests(unittest.TestCase):
         logic = {'method': [{'var': 'today'}, 'isoformat']}
         data = {'today': todays_date}
         returned_value = jsonLogic(logic, data)
-        self.assertIsInstance(returned_value, str)
+        self.assertIsInstance(returned_value, str)#six.text_type)
         self.assertEqual(returned_value, todays_date.isoformat())
 
     def test_method_operation_with_method_with_arguments(self):

--- a/tests.py
+++ b/tests.py
@@ -56,7 +56,7 @@ class SharedJsonLogicTests(unittest.TestCase):
 
 
 UNSUPPORTED_OPERATIONS = (
-    "?:", "substr", "filter", "map", "reduce", "all", "none", "some")
+    "substr", "filter", "map", "reduce", "all", "none", "some")
 skipped_tests_count = 0
 
 SHARED_TESTS = json.loads(
@@ -135,6 +135,17 @@ class SpecificJsonLogicTest(unittest.TestCase):
             jsonLogic(logic, {'a': 2}), {'test': 2, 'data': 'else if'})
         self.assertEqual(
             jsonLogic(logic, {'a': 3}), {'test': 3, 'data': 'else'})
+
+    def test_iif_can_return_non_logic_dictionaries(self):
+        logic = {'?:': [
+            {'==': [{'var': 'a'}, 1]},
+            {'test': 1, 'data': 'if'},
+            {'test': 2, 'data': 'else'}
+        ]}
+        self.assertEqual(
+            jsonLogic(logic, {'a': 1}), {'test': 1, 'data': 'if'})
+        self.assertEqual(
+            jsonLogic(logic, {'a': 2}), {'test': 2, 'data': 'else'})
 
     def test_log_forwards_first_argument_to_logging_module_at_info_level(self):
         # with self.assertLogs('json_logic', logging.INFO) as log:

--- a/tests.py
+++ b/tests.py
@@ -9,7 +9,7 @@ try:
     from urllib.request import urlopen
 except ImportError:
     from urllib2 import urlopen
-from json_logic import jsonLogic
+from json_logic import jsonLogic, is_logic
 
 
 # Python 2 fallback
@@ -108,6 +108,34 @@ class SpecificJsonLogicTest(unittest.TestCase):
             jsonLogic(logic, {'a': "test"}),
             [3, "test", "no", "just some data"])
 
+    def test_single_non_logic_dictionary_can_be_passed_through(self):
+        logic = {'test': 1, 'data': 'single'}
+        self.assertEqual(jsonLogic(logic), {'test': 1, 'data': 'single'})
+
+    def test_array_of_logic_entries_can_return_non_logic_dictionaries(self):
+        logic = [
+            {'+': [1, 2]},
+            {'test': 1, 'data': 'if'}
+        ]
+        self.assertSequenceEqual(
+            jsonLogic(logic),
+            [3, {'test': 1, 'data': 'if'}])
+
+    def test_if_can_return_non_logic_dictionaries(self):
+        logic = {'if': [
+            {'==': [{'var': 'a'}, 1]},
+            {'test': 1, 'data': 'if'},
+            {'==': [{'var': 'a'}, 2]},
+            {'test': 2, 'data': 'else if'},
+            {'test': 3, 'data': 'else'}
+        ]}
+        self.assertEqual(
+            jsonLogic(logic, {'a': 1}), {'test': 1, 'data': 'if'})
+        self.assertEqual(
+            jsonLogic(logic, {'a': 2}), {'test': 2, 'data': 'else if'})
+        self.assertEqual(
+            jsonLogic(logic, {'a': 3}), {'test': 3, 'data': 'else'})
+
     def test_log_forwards_first_argument_to_logging_module_at_info_level(self):
         # with self.assertLogs('json_logic', logging.INFO) as log:
         jsonLogic({'log': 'apple'})
@@ -157,6 +185,19 @@ class SpecificJsonLogicTest(unittest.TestCase):
         self.assertIs(jsonLogic({'%': [2, 2]}), 0)
         self.assertIs(jsonLogic({'%': [4, 3]}), 1)
         self.assertEqual(jsonLogic({'%': [2, 1.5]}), 0.5)
+
+    def test_is_logic_function(self):
+        # Returns True for logic entries
+        self.assertTrue(is_logic({'>': [2, 1]}))
+        self.assertTrue(is_logic({'+': [1, 2]}))
+        # Returns False for non-logic entries
+        self.assertFalse(is_logic(5))
+        self.assertFalse(is_logic(True))
+        self.assertFalse(is_logic([1, 2, 3]))
+        self.assertFalse(is_logic({}))
+        self.assertFalse(is_logic({'two': 'keys', 'per': 'dictionary'}))
+        # Array of logic entries is not considered a logic entry itself
+        self.assertFalse(is_logic([{'>': [2, 1]}, {'+': [1, 2]}]))
 
 
 if __name__ == '__main__':

--- a/tests.py
+++ b/tests.py
@@ -13,6 +13,7 @@ except ImportError:
 from json_logic import \
     jsonLogic, \
     is_logic, \
+    uses_data, \
     operations, \
     add_operation, \
     rm_operation
@@ -375,6 +376,29 @@ class SpecificJsonLogicTest(unittest.TestCase):
         self.assertFalse(is_logic({'two': 'keys', 'per': 'dictionary'}))
         # Array of logic entries is not considered a logic entry itself
         self.assertFalse(is_logic([{'>': [2, 1]}, {'+': [1, 2]}]))
+
+    def test_uses_data_function_returns_variable_names(self):
+        logic = {'+': [{'var': 'a'}, {'var': ['b', 2]}, 3, {'var': ['c']}]}
+        variables = uses_data(logic)
+        self.assertSequenceEqual(variables, ['a', 'b', 'c'])
+
+    def test_uses_data_function_returns_nested_variable_names(self):
+        logic = {'if': [
+            {'>': [{'var': 'a'}, {'var': ['b']}]},
+            {'var': ['c', 3]},
+            {'+': [{'var': 'd'}, 10]}
+        ]}
+        variables = uses_data(logic)
+        self.assertSequenceEqual(variables, ['a', 'b', 'c', 'd'])
+
+    def test_uses_data_function_returns_unique_variable_names(self):
+        logic = {'if': [
+            {'>': [{'var': 'a'}, {'var': 'b'}]},
+            {'var': 'a'},
+            {'*': [{'var': 'b'}, 2]}
+        ]}
+        variables = uses_data(logic)
+        self.assertSequenceEqual(variables, ['a', 'b'])
 
     def test_operations_value_exposes_all_operations(self):
         exposable_operations = (

--- a/tests.py
+++ b/tests.py
@@ -56,7 +56,7 @@ class SharedJsonLogicTests(unittest.TestCase):
 
 
 UNSUPPORTED_OPERATIONS = (
-    "substr", "filter", "map", "reduce", "all", "none", "some")
+    "filter", "map", "reduce", "all", "none", "some")
 skipped_tests_count = 0
 
 SHARED_TESTS = json.loads(

--- a/tests.py
+++ b/tests.py
@@ -181,6 +181,14 @@ class AdditionalJsonLogicTests(unittest.TestCase):
             jsonLogic({'===': [10000000000000000000, 10000000000000000000.0]}),
             True)
 
+    def test_less_then_type_coercion_peculiarities(self):
+        self.assertIs(jsonLogic({'<': ["11", 2, "3"]}), False)
+        self.assertIs(jsonLogic({'<': ["11", "2", 3]}), True)
+
+    def test_less_then_or_equal_to_type_coercion_peculiarities(self):
+        self.assertIs(jsonLogic({'<=': ["11", 2, "3"]}), False)
+        self.assertIs(jsonLogic({'<=': ["11", "2", 3]}), True)
+
     def test_arithmetic_operations_convert_data_to_apropriate_numerics(self):
         # Conversion
         self.assertIs(jsonLogic({'+': [1]}), 1)

--- a/tests.py
+++ b/tests.py
@@ -55,20 +55,12 @@ class SharedJsonLogicTests(unittest.TestCase):
         cls.cnt += 1
 
 
-UNSUPPORTED_OPERATIONS = (
-    "filter", "map", "reduce", "all", "none", "some")
-skipped_tests_count = 0
-
 SHARED_TESTS = json.loads(
     urlopen("http://jsonlogic.com/tests.json").read().decode('utf-8'))
 
 for item in SHARED_TESTS:
     if isinstance(item, list):
-        if any(("'%s'" % op in str(item[0])) for op in UNSUPPORTED_OPERATIONS):
-            skipped_tests_count += 1
-        else:
-            SharedJsonLogicTests.create_test(*item)
-print("Skipped %d shared test(s)" % skipped_tests_count)
+        SharedJsonLogicTests.create_test(*item)
 
 
 class SpecificJsonLogicTest(unittest.TestCase):

--- a/tests.py
+++ b/tests.py
@@ -222,7 +222,7 @@ class AdditionalJsonLogicTests(unittest.TestCase):
         logic = {'method': [{'var': 'today'}, 'isoformat']}
         data = {'today': todays_date}
         returned_value = jsonLogic(logic, data)
-        self.assertIsInstance(returned_value, str)#six.text_type)
+        self.assertIsInstance(returned_value, six.string_types)
         self.assertEqual(returned_value, todays_date.isoformat())
 
     def test_method_operation_with_method_with_arguments(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     clean,
-    py{27,33,34,35},pypy
+    py{27,33,34,35,36},pypy
     stats
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     clean,
-    py{27,33,34,35,36},pypy
+    py{27,33,34,35,36,37},pypy
     stats
 
 [testenv]


### PR DESCRIPTION
Hi @nadirizr ,

I was going to update the package to match the current JS version and tried changing a few things.

So what you see here is practically a complete rewrite of the package that makes it [almost] 100% compatible with the current json-logic-js implementation (think it's v1.2.1), including all operators, is_logic(), uses_data() and rule_like() functions, adding custom operators, correct evaluation/non-evaluation of it/and/or conditions  etc. It passes all shared tests from jsonlogic.com (both tests.json and rule_like.json), as well as a number of additional tests.

It also changes the way some operators work to make them behave the same way as their JS counterparts  do. I.e.: **{"===": [2, 2.0]} == True**. This is done to make things consistent across different language implementations. So that the above example could be evaluated to the same values in both Python and JavaScript.

Unfortunately, for the same reason it also replicates some JS bugs. I.e.: **'all'** operator stops at first falsy value, while **'some'/'none'** operators evaluate all values regardless of the result.

There are also some language-specific discrepancies still left. I.e.:
Python: **{"==": [[1,2], [1,2]]} == True**
Javascript: **{"==": [[1,2], [1,2]]} == False**
or
Python: **{"-": [2, None]} raises Exception**
Javascript: **{"-": [2, null]} == 2**
But those things should probably be fixed on the JS side (I've tried contacting @jwadhams regarding this).

But all-in-all, this is a full implementation if the current JsonLogic library version with named, traceable methods, descriptive docstrings and passable tests.